### PR TITLE
Enable custom OCaml LSP server name in the config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ unrealeased
 
 - Improve the error message when the identifier is not found
   [\27](https://github.com/tarides/ocaml.nvim/pull/27)
+- Enable custom OCaml LSP server name in the config
+  [\26](https://github.com/tarides/ocaml.nvim/pull/26)
 
 ocaml.nvim 1.0.0
 -----------

--- a/README.md
+++ b/README.md
@@ -88,13 +88,18 @@ require("lazy").setup({
 
 ## Customization
 
-You can customize all the keymaps available that doesn't have mandatory arguments.
+It is possible to customize the name of the OCaml LSP client.
+By default, the `client` is set to `ocamllsp`, but you can change it in the `params` array.
+You can also customize all the keymaps available that doesn't have mandatory arguments.
 To do that, you need to give the `setup` function the `keymaps` array.
 Every keymap you provide should be a string and will overwrite the default one specified in the [Usage](#usage) table.
-Below is the list of the available keymaps you can edit:
+Add the following to your configuration and edit both `params` and `keymaps` lists as needed.
 
 ```lua
 require("ocaml").setup({
+  params = {
+    client = "ocamllsp",
+  },
   -- If you replace this section with {} it will not setup any
   -- keymaps.
   keymaps = {

--- a/lua/ocaml/config.lua
+++ b/lua/ocaml/config.lua
@@ -1,6 +1,9 @@
 local vim = vim
 local M = {}
 
+---@class OCamlConfigParam
+---@field client string|?
+
 ---@class OCamlConfigKeymaps
 ---@field jump_next_hole string|?
 ---@field jump_prev_hole string|?
@@ -18,10 +21,14 @@ local M = {}
 
 ---@class ocaml.config.OCamlConfig
 ---@field keymaps OCamlConfigKeymaps
+---@field params OCamlConfigParam
 
 --- Default values
 --- @type ocaml.config.OCamlConfig
 local default = {
+  params = {
+    client = "ocamllsp",
+  },
   keymaps = {
     jump_next_hole = "<leader>n",
     jump_prev_hole = "<leader>p",

--- a/lua/ocaml/init.lua
+++ b/lua/ocaml/init.lua
@@ -6,14 +6,15 @@ local vim = vim
 local api = vim.api
 local config = require("ocaml.config")
 local ui = require("ocaml.ui")
+local client_name = "ocamllsp"
 
 -- 5.1 Lua JUT Runtime compatibility
 table.unpack = table.unpack or unpack
 
 local function get_server()
-  local clients = vim.lsp.get_clients({ name = "ocamllsp" })
+  local clients = vim.lsp.get_clients({ name = client_name })
   for _, client in ipairs(clients) do
-    if client.name == "ocamllsp" then
+    if client.name == client_name then
       return client
     end
   end
@@ -24,7 +25,7 @@ local function with_server(callback)
   if server then
     return callback(server)
   end
-  vim.notify("No OCaml LSP server available", vim.log.levels.ERROR)
+  vim.notify("No OCaml LSP server available with the name " .. client_name .. ".", vim.log.levels.ERROR)
 end
 
 function M.jump_to_hole(dir, range, bufnr)
@@ -547,6 +548,7 @@ end
 ---@param user_config ocaml.config.OCamlConfig|?
 function M.setup(user_config)
   local user_opts = config.build(user_config)
+  client_name = user_opts.params.client
 
   api.nvim_create_autocmd("FileType", {
     pattern = { "ocaml", "ocaml.interface" },


### PR DESCRIPTION
This PR aims to fix #25 .
It adds a new field in the customization parameters to let the user enter a custom name for the LSP server.