### PR TITLE
Add CI workflow for changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,21 @@
+name: changelog
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog-needed') }}
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: git diff
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: |
+        ! git diff --exit-code origin/$BASE_REF -- CHANGES.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 unrealeased
 -----------
 
+- Add CI workflow for changelog
+  [\31](https://github.com/tarides/ocaml.nvim/pull/31)
 - Some typo and reformulatoin
   [\28](https://github.com/tarides/ocaml.nvim/pull/28)
 - Improve the error message when the identifier is not found


### PR DESCRIPTION
This pull request adds a GitHub workflow to ensure that every new pull request is documented in the changelog. For pull requests not related to improving the plugin, for example, release-related, the workflow can be bypassed by labeling the pull request with `no-changelog-needed`.